### PR TITLE
fix: protected for chart and https server for loacl host

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@deriv/deriv-api": "^1.0.15",
         "@deriv/deriv-charts": "^2.8.0",
         "@deriv/quill-icons": "^2.2.2",
-        "@rsbuild/plugin-basic-ssl": "^1.1.1",
         "@rsbuild/plugin-sass": "^1.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -20,6 +19,7 @@
       },
       "devDependencies": {
         "@rsbuild/core": "^1.1.8",
+        "@rsbuild/plugin-basic-ssl": "^1.1.1",
         "@rsbuild/plugin-react": "^1.0.7",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
@@ -473,6 +473,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@rsbuild/plugin-basic-ssl/-/plugin-basic-ssl-1.1.1.tgz",
       "integrity": "sha512-q4u7H8yh/S/DHwxG85bWbGXFiVV9RMDJDupOBHJVPtevU9mLCB4n5Qbrxu/l8CCdmZcBlvfWGjkDA/YoY61dig==",
+      "dev": true,
       "dependencies": {
         "selfsigned": "^2.4.1"
       },
@@ -1033,6 +1034,7 @@
       "version": "22.10.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
       "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1041,6 +1043,7 @@
       "version": "1.3.11",
       "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
       "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3286,6 +3289,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "dev": true,
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -6935,6 +6939,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
       "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "dev": true,
       "dependencies": {
         "@types/node-forge": "^1.3.0",
         "node-forge": "^1"
@@ -7756,7 +7761,8 @@
     "node_modules/undici-types": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@deriv/deriv-api": "^1.0.15",
     "@deriv/deriv-charts": "^2.8.0",
     "@deriv/quill-icons": "^2.2.2",
-    "@rsbuild/plugin-basic-ssl": "^1.1.1",
     "@rsbuild/plugin-sass": "^1.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -20,6 +19,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^1.1.8",
+    "@rsbuild/plugin-basic-ssl": "^1.1.1",
     "@rsbuild/plugin-react": "^1.0.7",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "@rsbuild/core";
 import { pluginReact } from "@rsbuild/plugin-react";
 import { pluginSass } from "@rsbuild/plugin-sass";
+import { pluginBasicSsl } from "@rsbuild/plugin-basic-ssl";
 
 const path = require("path");
 
@@ -14,6 +15,7 @@ export default defineConfig({
       exclude: /node_modules/,
     }),
     pluginReact(),
+    pluginBasicSsl(),
   ],
   source: {
     entry: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,14 +51,7 @@ const AppContent: React.FC = () => {
       <Header />
       <Routes>
         <Route path="/" element={<Homepage />} />
-        <Route
-          path="/dashboard"
-          element={
-            <ProtectedRoute>
-              <DerivTrading />
-            </ProtectedRoute>
-          }
-        />
+        <Route path="/dashboard" element={<DerivTrading />} />
       </Routes>
     </Suspense>
   );


### PR DESCRIPTION
## Summary by Sourcery

Remove ProtectedRoute from DerivTrading component and enable HTTPS for local development server.

Bug Fixes:
- Removed unnecessary protection from `/dashboard`.
- Enabled HTTPS on the local development server.